### PR TITLE
Optional ep

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -179,7 +179,7 @@ void HandleSIGABORT(int sig)
     backtrace();
     exit(1);
 }
-#endif 
+#endif
 
 bool static InitError(const std::string &str)
 {
@@ -338,6 +338,7 @@ std::string HelpMessage(HelpMessageMode hmm)
     strUsage += "  -rpcport=<port>        " + _("Listen for JSON-RPC connections on <port> (default: 8252 or testnet: 18252)") + "\n";
     strUsage += "  -rpcallowip=<ip>       " + _("Allow JSON-RPC connections from specified IP address") + "\n";
     strUsage += "  -rpcthreads=<n>        " + _("Set the number of threads to service RPC calls (default: 4)") + "\n";
+    strUsage += "  -epamounts=<n>         " + _("Use Extended Precision amounts in RPC calls (default: 1, 0 to disable)") + "\n";
 
     strUsage += "\n" + _("RPC SSL options: (see the Cryptonite Wiki for SSL setup instructions)") + "\n";
     strUsage += "  -rpcssl                                  " + _("Use OpenSSL (https) for JSON-RPC connections") + "\n";
@@ -548,6 +549,10 @@ bool AppInit2(boost::thread_group& threadGroup)
         nMaxConnections = nFD - MIN_CORE_FILEDESCRIPTORS;
 
     // ********************************************************* Step 3: parameter-to-internal-flags
+
+    fEPAmounts = (GetArg("-epamounts", 1) == 1);
+    if (fEPAmounts) LogPrintf("Using Extented Precision amounts\n");
+    else LogPrintf("Using Standard Precision amounts\n");
 
     fDebug = !mapMultiArgs["-debug"].empty();
     // Special-case: if -debug=0/-nodebug is set, turn off debugging messages

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -96,6 +96,7 @@ bool fNoListen = false;
 bool fLogTimestamps = false;
 volatile bool fReopenDebugLog = false;
 CClientUIInterface uiInterface;
+bool fEPAmounts = true;
 
 // Init OpenSSL library multithreading support
 static CCriticalSection** ppmutexOpenSSL;
@@ -478,7 +479,7 @@ static void InterpretNegativeSetting(string name, map<string, string>& mapSettin
 std::string strCommandLine;
 
 void ParseParameters(int argc, const char* const argv[])
-{   
+{
     for(int i=0; i < argc; i++)
     	strCommandLine += std::string(argv[i]) + " ";
 

--- a/src/util.h
+++ b/src/util.h
@@ -37,7 +37,7 @@ class uint256;
 
 static const uint64_t COIN = 10000000000;
 static const uint64_t CENT = 100000000;
-static const uint64_t COINS = UINT64_MAX/COIN;	
+static const uint64_t COINS = UINT64_MAX/COIN;
 
 extern std::string strCommandLine;
 
@@ -118,6 +118,7 @@ extern std::string strMiscWarning;
 extern bool fNoListen;
 extern bool fLogTimestamps;
 extern volatile bool fReopenDebugLog;
+extern bool fEPAmounts;
 
 void RandAddSeed();
 void RandAddSeedPerfmon();


### PR DESCRIPTION
Added option to disable Extended Precision amounts in RPC calls (both requests and responses).
Some services, like exchanges, might prefer the classic format without "ep" at the end; in that case, use the "epamounts" option set to 0 (default 1).