### PR TITLE
Optional string amounts

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -339,6 +339,7 @@ std::string HelpMessage(HelpMessageMode hmm)
     strUsage += "  -rpcallowip=<ip>       " + _("Allow JSON-RPC connections from specified IP address") + "\n";
     strUsage += "  -rpcthreads=<n>        " + _("Set the number of threads to service RPC calls (default: 4)") + "\n";
     strUsage += "  -epamounts=<n>         " + _("Use Extended Precision amounts in RPC calls (default: 1, 0 to disable)") + "\n";
+    strUsage += "  -stringamounts=<n>     " + _("Use string type amounts in RPC calls (default: 1, 0 to disable); epamounts = 1 forces this to 1") + "\n";
 
     strUsage += "\n" + _("RPC SSL options: (see the Cryptonite Wiki for SSL setup instructions)") + "\n";
     strUsage += "  -rpcssl                                  " + _("Use OpenSSL (https) for JSON-RPC connections") + "\n";
@@ -553,6 +554,10 @@ bool AppInit2(boost::thread_group& threadGroup)
     fEPAmounts = (GetArg("-epamounts", 1) == 1);
     if (fEPAmounts) LogPrintf("Using Extented Precision amounts\n");
     else LogPrintf("Using Standard Precision amounts\n");
+
+    fStringAmounts = (GetArg("-stringamounts", 1) == 1);
+    if (fStringAmounts) LogPrintf("Using String RPC amounts\n");
+    else LogPrintf("Using Numeric RPC amounts\n");
 
     fDebug = !mapMultiArgs["-debug"].empty();
     // Special-case: if -debug=0/-nodebug is set, turn off debugging messages

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -83,7 +83,7 @@ void RPCTypeCheck(const Object& o,
 
 uint64_t AmountFromValue(const Value& value)
 {
-	if (value.type() != str_type)
+	if (value.type() != str_type and (fStringAmounts or fEPAmounts))
 		throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount, not string");
 
 	const char *str = value.get_str().c_str();
@@ -156,7 +156,8 @@ Value ValueFromAmount(uint64_t v)
 	}
     buf[idx++] = 0;
 //		snprintf(buf, 63, "%lu", v);
-  return string(buf);
+	if (fStringAmounts or fEPAmounts) return string(buf);
+	else return atof(buf);
 }
 
 std::string HexBits(unsigned int nBits)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -97,6 +97,7 @@ bool fLogTimestamps = false;
 volatile bool fReopenDebugLog = false;
 CClientUIInterface uiInterface;
 bool fEPAmounts = true;
+bool fStringAmounts = true;
 
 // Init OpenSSL library multithreading support
 static CCriticalSection** ppmutexOpenSSL;

--- a/src/util.h
+++ b/src/util.h
@@ -119,6 +119,7 @@ extern bool fNoListen;
 extern bool fLogTimestamps;
 extern volatile bool fReopenDebugLog;
 extern bool fEPAmounts;
+extern bool fStringAmounts;
 
 void RandAddSeed();
 void RandAddSeedPerfmon();


### PR DESCRIPTION
Added "stringamounts" option, to be used on commandline daemon launch (-stringamounts=0) or as config file option.
"Use string type amounts in RPC calls (default: 1, 0 to disable); epamounts = 1 forces this to 1"
Setting this to 0, along with epamounts=0, enables classic amounts like in bitcoin (without extended precision and numeric type).