### PR TITLE
Gui updates

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>RPCConsole</class>
- <widget class="QWidget" name="RPCConsole">
+ <widget class="QDialog" name="RPCConsole">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -13,8 +13,8 @@
   <property name="windowTitle">
    <string>Debug window</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
-   <item>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
       <number>0</number>
@@ -23,10 +23,7 @@
       <attribute name="title">
        <string>&amp;Information</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
-       <property name="horizontalSpacing">
-        <number>12</number>
-       </property>
+      <layout class="QGridLayout" name="gridLayout_4">
        <item row="0" column="0">
         <widget class="QLabel" name="label_9">
          <property name="font">
@@ -329,19 +326,6 @@
         </widget>
        </item>
        <item row="14" column="0">
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="15" column="0">
         <widget class="QLabel" name="labelDebugLogfile">
          <property name="font">
           <font>
@@ -356,6 +340,12 @@
        </item>
        <item row="15" column="0">
         <widget class="QPushButton" name="openDebugLogfileButton">
+         <property name="minimumSize">
+          <size>
+           <width>120</width>
+           <height>0</height>
+          </size>
+         </property>
          <property name="toolTip">
           <string>Open the Cryptonite debug log file from the current data directory. This can take a few seconds for large log files.</string>
          </property>
@@ -367,20 +357,34 @@
          </property>
         </widget>
        </item>
-       <item row="16" column="0">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
       </layout>
+      <zorder>labelDebugLogfile</zorder>
+      <zorder>label_9</zorder>
+      <zorder>label_5</zorder>
+      <zorder>clientName</zorder>
+      <zorder>label_6</zorder>
+      <zorder>clientVersion</zorder>
+      <zorder>label_14</zorder>
+      <zorder>openSSLVersion</zorder>
+      <zorder>label_berkeleyDBVersion</zorder>
+      <zorder>berkeleyDBVersion</zorder>
+      <zorder>label_12</zorder>
+      <zorder>dataDir</zorder>
+      <zorder>label_13</zorder>
+      <zorder>startupTime</zorder>
+      <zorder>label_11</zorder>
+      <zorder>label_8</zorder>
+      <zorder>networkName</zorder>
+      <zorder>label_7</zorder>
+      <zorder>numberOfConnections</zorder>
+      <zorder>label_10</zorder>
+      <zorder>label_3</zorder>
+      <zorder>numberOfBlocks</zorder>
+      <zorder>label_4</zorder>
+      <zorder>totalBlocks</zorder>
+      <zorder>label_2</zorder>
+      <zorder>lastBlockTime</zorder>
+      <zorder>openDebugLogfileButton</zorder>
      </widget>
      <widget class="QWidget" name="tab_console">
       <attribute name="title">
@@ -454,7 +458,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab">
+     <widget class="QWidget" name="tab_nettraffic">
       <attribute name="title">
        <string>&amp;Network Traffic</string>
       </attribute>
@@ -709,6 +713,19 @@
        <string>&amp;Peers</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2">
+       <item row="0" column="0" rowspan="2">
+        <widget class="QTableView" name="peerWidget">
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="sortingEnabled">
+          <bool>true</bool>
+         </property>
+         <attribute name="horizontalHeaderHighlightSections">
+          <bool>false</bool>
+         </attribute>
+        </widget>
+       </item>
        <item row="0" column="1">
         <widget class="QLabel" name="peerHeading">
          <property name="sizePolicy">
@@ -717,262 +734,331 @@
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
+         <property name="minimumSize">
+          <size>
+           <width>300</width>
+           <height>32</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>10</pointsize>
+          </font>
+         </property>
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
          <property name="text">
           <string>Select a peer to view detailed information.</string>
          </property>
-         <property name="margin">
-          <number>3</number>
+         <property name="alignment">
+          <set>Qt::AlignHCenter|Qt::AlignTop</set>
          </property>
-        </widget>
-       </item>
-       <item row="0" column="0" rowspan="2">
-        <widget class="QTableView" name="peerWidget">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="horizontalScrollBarPolicy">
-          <enum>Qt::ScrollBarAlwaysOff</enum>
-         </property>
-         <property name="editTriggers">
-          <set>QAbstractItemView::AnyKeyPressed|QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed</set>
-         </property>
-         <property name="sortingEnabled">
+         <property name="wordWrap">
           <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
        <item row="1" column="1">
         <widget class="QWidget" name="detailWidget" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+         <property name="minimumSize">
+          <size>
+           <width>300</width>
+           <height>0</height>
+          </size>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
-          <property name="leftMargin">
-           <number>3</number>
-          </property>
-          <item row="12" column="0">
-           <widget class="QLabel" name="label_21">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_23">
             <property name="text">
-             <string>Version:</string>
+             <string>Direction</string>
             </property>
            </widget>
           </item>
-          <item row="11" column="1">
-           <widget class="QLabel" name="peerPingTime">
+          <item row="0" column="2">
+           <widget class="QLabel" name="peerDirection">
+            <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
+            </property>
             <property name="text">
              <string>N/A</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_21">
+            <property name="text">
+             <string>Version</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QLabel" name="peerVersion">
+            <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
+            </property>
+            <property name="text">
+             <string>N/A</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_28">
+            <property name="text">
+             <string>User Agent</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QLabel" name="peerSubversion">
+            <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
+            </property>
+            <property name="text">
+             <string>N/A</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Services</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="QLabel" name="peerServices">
+            <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
+            </property>
+            <property name="text">
+             <string>N/A</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_25">
+            <property name="text">
+             <string>Sync Node</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="2">
+           <widget class="QLabel" name="peerSyncNode">
+            <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
+            </property>
+            <property name="text">
+             <string>N/A</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
             </property>
            </widget>
           </item>
           <item row="5" column="0">
-           <widget class="QLabel" name="label_19">
-            <property name="text">
-             <string>Last Receive:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="14" column="0">
-           <widget class="QLabel" name="label_28">
-            <property name="text">
-             <string>User Agent:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="12" column="1">
-           <widget class="QLabel" name="peerVersion">
-            <property name="text">
-             <string>N/A</string>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="1">
-           <widget class="QLabel" name="peerConnTime">
-            <property name="minimumSize">
-             <size>
-              <width>160</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>N/A</string>
-            </property>
-           </widget>
-          </item>
-          <item row="11" column="0">
-           <widget class="QLabel" name="label_26">
-            <property name="text">
-             <string>Ping Time:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <widget class="QLabel" name="peerLastRecv">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>N/A</string>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="0">
-           <widget class="QLabel" name="label_22">
-            <property name="text">
-             <string>Connection Time:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="1">
-           <widget class="QLabel" name="peerBytesSent">
-            <property name="text">
-             <string>N/A</string>
-            </property>
-           </widget>
-          </item>
-          <item row="14" column="1">
-           <widget class="QLabel" name="peerSubversion">
-            <property name="text">
-             <string>N/A</string>
-            </property>
-           </widget>
-          </item>
-          <item row="15" column="0">
            <widget class="QLabel" name="label_29">
             <property name="text">
-             <string>Starting Height:</string>
+             <string>Starting Height</string>
             </property>
            </widget>
           </item>
-          <item row="7" column="1">
-           <widget class="QLabel" name="peerBytesRecv">
+          <item row="5" column="2">
+           <widget class="QLabel" name="peerHeight">
+            <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
+            </property>
             <property name="text">
              <string>N/A</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
             </property>
            </widget>
           </item>
           <item row="6" column="0">
+           <widget class="QLabel" name="label_22">
+            <property name="text">
+             <string>Connection Time</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="2">
+           <widget class="QLabel" name="peerConnTime">
+            <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
+            </property>
+            <property name="text">
+             <string>N/A</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="label_15">
+            <property name="text">
+             <string>Last Send</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="2">
+           <widget class="QLabel" name="peerLastSend">
+            <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
+            </property>
+            <property name="text">
+             <string>N/A</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="label_19">
+            <property name="text">
+             <string>Last Receive</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="2">
+           <widget class="QLabel" name="peerLastRecv">
+            <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
+            </property>
+            <property name="text">
+             <string>N/A</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="0">
            <widget class="QLabel" name="label_18">
             <property name="text">
              <string>Sent:</string>
             </property>
            </widget>
           </item>
-          <item row="7" column="0">
+          <item row="9" column="2">
+           <widget class="QLabel" name="peerBytesSent">
+            <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
+            </property>
+            <property name="text">
+             <string>N/A</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="0">
            <widget class="QLabel" name="label_20">
             <property name="text">
              <string>Received:</string>
             </property>
            </widget>
           </item>
-          <item row="15" column="1">
-           <widget class="QLabel" name="peerHeight">
+          <item row="10" column="2">
+           <widget class="QLabel" name="peerBytesRecv">
+            <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
+            </property>
             <property name="text">
              <string>N/A</string>
             </property>
-           </widget>
-          </item>
-          <item row="16" column="0">
-           <widget class="QLabel" name="label_24">
-            <property name="text">
-             <string>Ban Score:</string>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
             </property>
            </widget>
           </item>
-          <item row="16" column="1">
-           <widget class="QLabel" name="peerBanScore">
+          <item row="11" column="0">
+           <widget class="QLabel" name="label_26">
             <property name="text">
-             <string>N/A</string>
+             <string>Ping Time</string>
             </property>
            </widget>
           </item>
-          <item row="17" column="0">
-           <widget class="QLabel" name="label_23">
-            <property name="text">
-             <string>Direction:</string>
+          <item row="11" column="2">
+           <widget class="QLabel" name="peerPingTime">
+            <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
             </property>
-           </widget>
-          </item>
-          <item row="17" column="1">
-           <widget class="QLabel" name="peerDirection">
             <property name="text">
              <string>N/A</string>
             </property>
-           </widget>
-          </item>
-          <item row="19" column="0">
-           <widget class="QLabel" name="label_25">
-            <property name="text">
-             <string>Sync Node:</string>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
             </property>
            </widget>
           </item>
-          <item row="19" column="1">
-           <widget class="QLabel" name="peerSyncNode">
-            <property name="text">
-             <string>N/A</string>
+          <item row="12" column="1">
+           <spacer name="verticalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
             </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_15">
-            <property name="text">
-             <string>Last Send:</string>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
             </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_4">
-            <property name="text">
-             <string>Services:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_27">
-            <property name="text">
-             <string>IP Address/port:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QLabel" name="peerLastSend">
-            <property name="text">
-             <string>N/A</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QLabel" name="peerServices">
-            <property name="text">
-             <string>N/A</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLabel" name="peerAddr">
-            <property name="text">
-             <string>N/A</string>
-            </property>
-           </widget>
-          </item>
-          <item row="20" column="0">
-           <widget class="QWidget" name="widget" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
+           </spacer>
           </item>
          </layout>
         </widget>

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>740</width>
-    <height>450</height>
+    <height>469</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -33,7 +33,7 @@
         <widget class="QLabel" name="label_9">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
            <weight>75</weight>
            <bold>true</bold>
           </font>
@@ -47,7 +47,7 @@
         <widget class="QLabel" name="label_5">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
           </font>
          </property>
          <property name="text">
@@ -59,7 +59,7 @@
         <widget class="QLabel" name="clientName">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
           </font>
          </property>
          <property name="cursor">
@@ -80,7 +80,7 @@
         <widget class="QLabel" name="label_6">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
           </font>
          </property>
          <property name="text">
@@ -92,7 +92,7 @@
         <widget class="QLabel" name="clientVersion">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
           </font>
          </property>
          <property name="cursor">
@@ -113,7 +113,7 @@
         <widget class="QLabel" name="label_14">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
           </font>
          </property>
          <property name="text">
@@ -128,7 +128,7 @@
         <widget class="QLabel" name="openSSLVersion">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
           </font>
          </property>
          <property name="cursor">
@@ -149,7 +149,7 @@
         <widget class="QLabel" name="label_berkeleyDBVersion">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
           </font>
          </property>
          <property name="text">
@@ -164,7 +164,7 @@
         <widget class="QLabel" name="berkeleyDBVersion">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
           </font>
          </property>
          <property name="cursor">
@@ -185,7 +185,7 @@
         <widget class="QLabel" name="label_12">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
           </font>
          </property>
          <property name="text">
@@ -197,7 +197,7 @@
         <widget class="QLabel" name="dataDir">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
           </font>
          </property>
          <property name="cursor">
@@ -221,7 +221,7 @@
         <widget class="QLabel" name="label_13">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
           </font>
          </property>
          <property name="text">
@@ -233,7 +233,7 @@
         <widget class="QLabel" name="startupTime">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
           </font>
          </property>
          <property name="cursor">
@@ -254,7 +254,7 @@
         <widget class="QLabel" name="label_11">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
            <weight>75</weight>
            <bold>true</bold>
           </font>
@@ -268,7 +268,7 @@
         <widget class="QLabel" name="label_8">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
           </font>
          </property>
          <property name="text">
@@ -280,7 +280,7 @@
         <widget class="QLabel" name="networkName">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
           </font>
          </property>
          <property name="cursor">
@@ -301,7 +301,7 @@
         <widget class="QLabel" name="label_7">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
           </font>
          </property>
          <property name="text">
@@ -313,7 +313,7 @@
         <widget class="QLabel" name="numberOfConnections">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
           </font>
          </property>
          <property name="cursor">
@@ -334,7 +334,7 @@
         <widget class="QLabel" name="label_10">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
            <weight>75</weight>
            <bold>true</bold>
           </font>
@@ -348,7 +348,7 @@
         <widget class="QLabel" name="label_3">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
           </font>
          </property>
          <property name="text">
@@ -360,7 +360,7 @@
         <widget class="QLabel" name="numberOfBlocks">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
           </font>
          </property>
          <property name="cursor">
@@ -381,7 +381,7 @@
         <widget class="QLabel" name="label_4">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
           </font>
          </property>
          <property name="text">
@@ -393,7 +393,7 @@
         <widget class="QLabel" name="totalBlocks">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
           </font>
          </property>
          <property name="cursor">
@@ -414,7 +414,7 @@
         <widget class="QLabel" name="label_2">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
           </font>
          </property>
          <property name="text">
@@ -426,7 +426,7 @@
         <widget class="QLabel" name="lastBlockTime">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
           </font>
          </property>
          <property name="cursor">
@@ -447,7 +447,7 @@
         <widget class="QLabel" name="labelDebugLogfile">
          <property name="font">
           <font>
-           <pointsize>12</pointsize>
+           <pointsize>11</pointsize>
            <weight>75</weight>
            <bold>true</bold>
           </font>

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -16,6 +16,11 @@
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
+     <property name="font">
+      <font>
+       <pointsize>11</pointsize>
+      </font>
+     </property>
      <property name="currentIndex">
       <number>0</number>
      </property>
@@ -23,11 +28,12 @@
       <attribute name="title">
        <string>&amp;Information</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout_4">
+      <layout class="QFormLayout" name="formLayout">
        <item row="0" column="0">
         <widget class="QLabel" name="label_9">
          <property name="font">
           <font>
+           <pointsize>12</pointsize>
            <weight>75</weight>
            <bold>true</bold>
           </font>
@@ -39,6 +45,11 @@
        </item>
        <item row="1" column="0">
         <widget class="QLabel" name="label_5">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
          <property name="text">
           <string>Client name</string>
          </property>
@@ -46,6 +57,11 @@
        </item>
        <item row="1" column="1">
         <widget class="QLabel" name="clientName">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -62,6 +78,11 @@
        </item>
        <item row="2" column="0">
         <widget class="QLabel" name="label_6">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
          <property name="text">
           <string>Client version</string>
          </property>
@@ -69,6 +90,11 @@
        </item>
        <item row="2" column="1">
         <widget class="QLabel" name="clientVersion">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -85,16 +111,26 @@
        </item>
        <item row="3" column="0">
         <widget class="QLabel" name="label_14">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
          <property name="text">
-          <string>Using OpenSSL version</string>
+          <string>OpenSSL version</string>
          </property>
          <property name="indent">
-          <number>10</number>
+          <number>0</number>
          </property>
         </widget>
        </item>
        <item row="3" column="1">
         <widget class="QLabel" name="openSSLVersion">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -111,16 +147,26 @@
        </item>
        <item row="4" column="0">
         <widget class="QLabel" name="label_berkeleyDBVersion">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
          <property name="text">
-          <string>Using BerkeleyDB version</string>
+          <string>BerkeleyDB version</string>
          </property>
          <property name="indent">
-          <number>10</number>
+          <number>0</number>
          </property>
         </widget>
        </item>
        <item row="4" column="1">
         <widget class="QLabel" name="berkeleyDBVersion">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -137,6 +183,11 @@
        </item>
        <item row="5" column="0">
         <widget class="QLabel" name="label_12">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
          <property name="text">
           <string>Datadir</string>
          </property>
@@ -144,6 +195,11 @@
        </item>
        <item row="5" column="1">
         <widget class="QLabel" name="dataDir">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -163,6 +219,11 @@
        </item>
        <item row="6" column="0">
         <widget class="QLabel" name="label_13">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
          <property name="text">
           <string>Startup time</string>
          </property>
@@ -170,6 +231,11 @@
        </item>
        <item row="6" column="1">
         <widget class="QLabel" name="startupTime">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -188,6 +254,7 @@
         <widget class="QLabel" name="label_11">
          <property name="font">
           <font>
+           <pointsize>12</pointsize>
            <weight>75</weight>
            <bold>true</bold>
           </font>
@@ -199,6 +266,11 @@
        </item>
        <item row="8" column="0">
         <widget class="QLabel" name="label_8">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
          <property name="text">
           <string>Name</string>
          </property>
@@ -206,6 +278,11 @@
        </item>
        <item row="8" column="1">
         <widget class="QLabel" name="networkName">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -222,6 +299,11 @@
        </item>
        <item row="9" column="0">
         <widget class="QLabel" name="label_7">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
          <property name="text">
           <string>Number of connections</string>
          </property>
@@ -229,6 +311,11 @@
        </item>
        <item row="9" column="1">
         <widget class="QLabel" name="numberOfConnections">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -247,6 +334,7 @@
         <widget class="QLabel" name="label_10">
          <property name="font">
           <font>
+           <pointsize>12</pointsize>
            <weight>75</weight>
            <bold>true</bold>
           </font>
@@ -258,6 +346,11 @@
        </item>
        <item row="11" column="0">
         <widget class="QLabel" name="label_3">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
          <property name="text">
           <string>Current number of blocks</string>
          </property>
@@ -265,6 +358,11 @@
        </item>
        <item row="11" column="1">
         <widget class="QLabel" name="numberOfBlocks">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -281,6 +379,11 @@
        </item>
        <item row="12" column="0">
         <widget class="QLabel" name="label_4">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
          <property name="text">
           <string>Estimated total blocks</string>
          </property>
@@ -288,6 +391,11 @@
        </item>
        <item row="12" column="1">
         <widget class="QLabel" name="totalBlocks">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -304,6 +412,11 @@
        </item>
        <item row="13" column="0">
         <widget class="QLabel" name="label_2">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
          <property name="text">
           <string>Last block time</string>
          </property>
@@ -311,6 +424,11 @@
        </item>
        <item row="13" column="1">
         <widget class="QLabel" name="lastBlockTime">
+         <property name="font">
+          <font>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -329,6 +447,7 @@
         <widget class="QLabel" name="labelDebugLogfile">
          <property name="font">
           <font>
+           <pointsize>12</pointsize>
            <weight>75</weight>
            <bold>true</bold>
           </font>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -11,6 +11,7 @@
 
 #include "core.h"
 #include "init.h"
+#include "main.h"
 #include "protocol.h"
 #include "util.h"
 
@@ -77,7 +78,11 @@ QString dateTimeStr(qint64 nTime)
 QFont bitcoinAddressFont()
 {
     QFont font("Monospace");
+#if QT_VERSION >= 0x040800
+    font.setStyleHint(QFont::Monospace);
+#else
     font.setStyleHint(QFont::TypeWriter);
+#endif
     return font;
 }
 
@@ -557,7 +562,7 @@ bool SetStartOnSystemStartup(bool fAutoStart)
     return true;
 }
 
-#elif defined(LINUX)
+#elif defined(Q_OS_LINUX)
 
 // Follow the Desktop Application Autostart Spec:
 //  http://standards.freedesktop.org/autostart-spec/autostart-spec-latest.html
@@ -762,7 +767,7 @@ QString formatServicesStr(uint64_t mask)
     QStringList strList;
 
     // Just scan the last 8 bits for now.
-    for (int i=0; i < 8; i++) {
+    for (int i = 0; i < 8; i++) {
         uint64_t check = 1 << i;
         if (mask & check)
         {
@@ -781,7 +786,11 @@ QString formatServicesStr(uint64_t mask)
         return strList.join(" & ");
     else
         return QObject::tr("None");
+}
 
+QString formatPingTime(double dPingTime)
+{
+    return dPingTime == 0 ? QObject::tr("N/A") : QString(QObject::tr("%1 s")).arg(QString::number(dPingTime, 'f', 3));
 }
 
 } // namespace GUIUtil

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -179,6 +179,8 @@ namespace GUIUtil
     /* Format CNodeStats.nServices bitmask into a user-readable string */
     QString formatServicesStr(uint64_t mask);
 
+    /* Format a CNodeCombinedStats.dPingTime into a user-readable string or display N/A, if 0*/
+    QString formatPingTime(double dPingTime);
 } // namespace GUIUtil
 
 #endif // GUIUTIL_H

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -11,20 +11,23 @@
 #include <QAbstractTableModel>
 #include <QStringList>
 
-class PeerTablePriv;
 class ClientModel;
+class PeerTablePriv;
 
+QT_BEGIN_NAMESPACE
 class QTimer;
+QT_END_NAMESPACE
 
 struct CNodeCombinedStats {
-    CNodeStats nodestats;
-    CNodeStateStats statestats;
+    CNodeStats nodeStats;
+    CNodeStateStats nodeStateStats;
+    bool fNodeStateStatsAvailable;
 };
 
 class NodeLessThan
 {
 public:
-    NodeLessThan(int nColumn, Qt::SortOrder fOrder):
+    NodeLessThan(int nColumn, Qt::SortOrder fOrder) :
         column(nColumn), order(fOrder) {}
     bool operator()(const CNodeCombinedStats &left, const CNodeCombinedStats &right) const;
 
@@ -45,13 +48,14 @@ public:
     explicit PeerTableModel(ClientModel *parent = 0);
     const CNodeCombinedStats *getNodeStats(int idx);
     int getRowByNodeId(NodeId nodeid);
-    void startAutoRefresh(int msecs);
+    void startAutoRefresh();
     void stopAutoRefresh();
 
     enum ColumnIndex {
-        Address = 0,
-        Subversion = 1,
-        Height = 2
+        NetNodeId = 0,
+        Address = 1,
+        Subversion = 2,
+        Ping = 3
     };
 
     /** @name Methods overridden from QAbstractTableModel
@@ -73,7 +77,6 @@ private:
     QStringList columns;
     PeerTablePriv *priv;
     QTimer *timer;
-
 };
 
 #endif // PEERTABLEMODEL_H

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -10,13 +10,15 @@
 #include "peertablemodel.h"
 
 #include "main.h"
-#include "util.h"
-
+#include "chainparams.h"
 #include "rpcserver.h"
 #include "rpcclient.h"
+#include "util.h"
 
 #include "json/json_spirit_value.h"
+#ifdef ENABLE_WALLET
 #include <db_cxx.h>
+#endif
 #include <openssl/crypto.h>
 
 #include <QKeyEvent>
@@ -196,15 +198,12 @@ void RPCExecutor::request(const QString &command)
 }
 
 RPCConsole::RPCConsole(QWidget *parent) :
-    QWidget(parent),
+    QDialog(parent),
     ui(new Ui::RPCConsole),
     clientModel(0),
-    historyPtr(0)
+    historyPtr(0),
+    cachedNodeid(-1)
 {
-    detailNodeStats = CNodeCombinedStats();
-    detailNodeStats.nodestats.nodeid = -1;
-    detailNodeStats.statestats.nMisbehavior = -1;
-
     ui->setupUi(this);
     GUIUtil::restoreWindowGeometry("nRPCConsoleWindow", this->size(), this);
 
@@ -230,7 +229,9 @@ RPCConsole::RPCConsole(QWidget *parent) :
 
     startExecutor();
     setTrafficGraphRange(INITIAL_TRAFFIC_GRAPH_MINS);
+
     ui->detailWidget->hide();
+    ui->peerHeading->setText(tr("Select a peer to view detailed information."));
 
     clear();
 }
@@ -275,7 +276,7 @@ bool RPCConsole::eventFilter(QObject* obj, QEvent *event)
             }
         }
     }
-    return QWidget::eventFilter(obj, event);
+    return QDialog::eventFilter(obj, event);
 }
 
 void RPCConsole::setClientModel(ClientModel *model)
@@ -302,14 +303,12 @@ void RPCConsole::setClientModel(ClientModel *model)
         ui->peerWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
         ui->peerWidget->setSelectionMode(QAbstractItemView::SingleSelection);
         ui->peerWidget->setColumnWidth(PeerTableModel::Address, ADDRESS_COLUMN_WIDTH);
-        columnResizingFixer = new GUIUtil::TableViewLastColumnResizingFixer(ui->peerWidget, MINIMUM_COLUMN_WIDTH, MINIMUM_COLUMN_WIDTH);
+        ui->peerWidget->setColumnWidth(PeerTableModel::Subversion, SUBVERSION_COLUMN_WIDTH);
+        ui->peerWidget->setColumnWidth(PeerTableModel::Ping, PING_COLUMN_WIDTH);
 
-        // connect the peerWidget's selection model to our peerSelected() handler
-        QItemSelectionModel *peerSelectModel = ui->peerWidget->selectionModel();
-        connect(peerSelectModel,
-                SIGNAL(selectionChanged(const QItemSelection &, const QItemSelection &)),
-                this,
-                SLOT(peerSelected(const QItemSelection &, const QItemSelection &)));
+        // connect the peerWidget selection model to our peerSelected() handler
+        connect(ui->peerWidget->selectionModel(), SIGNAL(selectionChanged(const QItemSelection &, const QItemSelection &)),
+             this, SLOT(peerSelected(const QItemSelection &, const QItemSelection &)));
         connect(model->getPeerTableModel(), SIGNAL(layoutChanged()), this, SLOT(peerLayoutChanged()));
 
         // Provide initial values
@@ -366,12 +365,11 @@ void RPCConsole::clear()
                         tr("Type <b>help</b> for an overview of available commands.")), true);
 }
 
-void RPCConsole::keyPressEvent(QKeyEvent *event)
+void RPCConsole::reject()
 {
-    if(windowType() != Qt::Widget && event->key() == Qt::Key_Escape)
-    {
-        close();
-    }
+    // Ignore escape keypress if this is not a seperate window
+    if(windowType() != Qt::Widget)
+        QDialog::reject();
 }
 
 void RPCConsole::message(int category, const QString &message, bool html)
@@ -420,8 +418,8 @@ void RPCConsole::on_lineEdit_returnPressed()
     {
         message(CMD_REQUEST, cmd);
         Q_EMIT cmdRequest(cmd);
-        // Truncate history from current position
-        history.erase(history.begin() + historyPtr, history.end());
+        // Remove command, if already in history
+        history.removeOne(cmd);
         // Append command to history
         history.append(cmd);
         // Enforce maximum history size
@@ -523,31 +521,26 @@ void RPCConsole::updateTrafficStats(quint64 totalBytesIn, quint64 totalBytesOut)
 
 void RPCConsole::peerSelected(const QItemSelection &selected, const QItemSelection &deselected)
 {
-    if (selected.indexes().isEmpty())
+    Q_UNUSED(deselected);
+
+    if (!clientModel || selected.indexes().isEmpty())
         return;
 
-    // mark the cached banscore as unknown
-    detailNodeStats.statestats.nMisbehavior = -1;
-
     const CNodeCombinedStats *stats = clientModel->getPeerTableModel()->getNodeStats(selected.indexes().first().row());
-
     if (stats)
     {
-        detailNodeStats.nodestats.nodeid = stats->nodestats.nodeid;
         updateNodeDetail(stats);
-        ui->detailWidget->show();
-        ui->detailWidget->setDisabled(false);
     }
 }
 
 void RPCConsole::peerLayoutChanged()
 {
-    const CNodeCombinedStats *stats = nullptr;
-    bool fUnselect = false, fReselect = false, fDisconnected = false;
-
-    if (detailNodeStats.nodestats.nodeid == -1)
-        // no node selected yet
+    if (!clientModel)
         return;
+
+    const CNodeCombinedStats *stats = nullptr;
+    bool fUnselect = false;
+    bool fReselect = false;
 
     // find the currently selected row
     int selectedRow;
@@ -559,14 +552,15 @@ void RPCConsole::peerLayoutChanged()
 
     // check if our detail node has a row in the table (it may not necessarily
     // be at selectedRow since its position can change after a layout change)
-    int detailNodeRow = clientModel->getPeerTableModel()->getRowByNodeId(detailNodeStats.nodestats.nodeid);
+    int detailNodeRow = clientModel->getPeerTableModel()->getRowByNodeId(cachedNodeid);
 
     if (detailNodeRow < 0)
     {
         // detail node dissapeared from table (node disconnected)
         fUnselect = true;
-        fDisconnected = true;
-        detailNodeStats.nodestats.nodeid = 0;
+        cachedNodeid = -1;
+        ui->detailWidget->hide();
+        ui->peerHeading->setText(tr("Select a peer to view detailed information."));
     }
     else
     {
@@ -584,7 +578,7 @@ void RPCConsole::peerLayoutChanged()
     if (fUnselect && selectedRow >= 0)
     {
         ui->peerWidget->selectionModel()->select(QItemSelection(selectedModelIndex.first(), selectedModelIndex.last()),
-                                                 QItemSelectionModel::Deselect);
+            QItemSelectionModel::Deselect);
     }
 
     if (fReselect)
@@ -594,82 +588,56 @@ void RPCConsole::peerLayoutChanged()
 
     if (stats)
         updateNodeDetail(stats);
-
-    if (fDisconnected)
-    {
-        ui->peerHeading->setText(QString(tr("Peer Disconnected")));
-        ui->detailWidget->setDisabled(true);
-        QDateTime dt = QDateTime::fromTime_t(detailNodeStats.nodestats.nLastSend);
-        if (detailNodeStats.nodestats.nLastSend)
-            ui->peerLastSend->setText(dt.toString("yyyy-MM-dd hh:mm:ss"));
-        dt.setTime_t(detailNodeStats.nodestats.nLastRecv);
-        if (detailNodeStats.nodestats.nLastRecv)
-            ui->peerLastRecv->setText(dt.toString("yyyy-MM-dd hh:mm:ss"));
-        dt.setTime_t(detailNodeStats.nodestats.nTimeConnected);
-        ui->peerConnTime->setText(dt.toString("yyyy-MM-dd hh:mm:ss"));
-    }
 }
 
-void RPCConsole::updateNodeDetail(const CNodeCombinedStats *combinedStats)
+void RPCConsole::updateNodeDetail(const CNodeCombinedStats *stats)
 {
-    CNodeStats stats = combinedStats->nodestats;
-
-    // keep a copy of timestamps, used to display dates upon disconnect
-    detailNodeStats.nodestats.nLastSend = stats.nLastSend;
-    detailNodeStats.nodestats.nLastRecv = stats.nLastRecv;
-    detailNodeStats.nodestats.nTimeConnected = stats.nTimeConnected;
+    // Update cached nodeid
+    cachedNodeid = stats->nodeStats.nodeid;
 
     // update the detail ui with latest node information
-    ui->peerHeading->setText(QString("<b>%1</b>").arg(tr("Node Detail")));
-    ui->peerAddr->setText(QString(stats.addrName.c_str()));
-    ui->peerServices->setText(GUIUtil::formatServicesStr(stats.nServices));
-    ui->peerLastSend->setText(stats.nLastSend ? GUIUtil::formatDurationStr(GetTime() - stats.nLastSend) : tr("never"));
-    ui->peerLastRecv->setText(stats.nLastRecv ? GUIUtil::formatDurationStr(GetTime() - stats.nLastRecv) : tr("never"));
-    ui->peerBytesSent->setText(FormatBytes(stats.nSendBytes));
-    ui->peerBytesRecv->setText(FormatBytes(stats.nRecvBytes));
-    ui->peerConnTime->setText(GUIUtil::formatDurationStr(GetTime() - stats.nTimeConnected));
-    ui->peerPingTime->setText(stats.dPingTime == 0 ? tr("N/A") : QString(tr("%1 secs")).arg(QString::number(stats.dPingTime, 'f', 3)));
-    ui->peerVersion->setText(QString("%1").arg(stats.nVersion));
-    ui->peerSubversion->setText(QString(stats.cleanSubVer.c_str()));
-    ui->peerDirection->setText(stats.fInbound ? tr("Inbound") : tr("Outbound"));
-    ui->peerHeight->setText(QString("%1").arg(stats.nStartingHeight));
-    ui->peerSyncNode->setText(stats.fSyncNode ? tr("Yes") : tr("No"));
+    QString peerAddrDetails(QString::fromStdString(stats->nodeStats.addrName));
+    if (!stats->nodeStats.addrLocal.empty())
+        peerAddrDetails += "<br />" + tr("via %1").arg(QString::fromStdString(stats->nodeStats.addrLocal));
+    ui->peerHeading->setText(peerAddrDetails);
+    ui->peerServices->setText(GUIUtil::formatServicesStr(stats->nodeStats.nServices));
+    ui->peerLastSend->setText(stats->nodeStats.nLastSend ? GUIUtil::formatDurationStr(GetTime() - stats->nodeStats.nLastSend) : tr("never"));
+    ui->peerLastRecv->setText(stats->nodeStats.nLastRecv ? GUIUtil::formatDurationStr(GetTime() - stats->nodeStats.nLastRecv) : tr("never"));
+    ui->peerBytesSent->setText(FormatBytes(stats->nodeStats.nSendBytes));
+    ui->peerBytesRecv->setText(FormatBytes(stats->nodeStats.nRecvBytes));
+    ui->peerConnTime->setText(GUIUtil::formatDurationStr(GetTime() - stats->nodeStats.nTimeConnected));
+    ui->peerPingTime->setText(GUIUtil::formatPingTime(stats->nodeStats.dPingTime));
+    ui->peerVersion->setText(QString("%1").arg(stats->nodeStats.nVersion));
+    ui->peerSubversion->setText(QString::fromStdString(stats->nodeStats.cleanSubVer));
+    ui->peerDirection->setText(stats->nodeStats.fInbound ? tr("Inbound") : tr("Outbound"));
+    ui->peerHeight->setText(QString("%1").arg(stats->nodeStats.nStartingHeight));
+    ui->peerSyncNode->setText(stats->nodeStats.fSyncNode ? tr("Yes") : tr("No"));
 
-    // if we can, display the peer's ban score
-    CNodeStateStats statestats = combinedStats->statestats;
-    if (statestats.nMisbehavior >= 0)
-    {
-        // we have a new nMisbehavor value - update the cache
-        detailNodeStats.statestats.nMisbehavior = statestats.nMisbehavior;
-    }
-
-    // pull the ban score from cache.  -1 means it hasn't been retrieved yet (lock busy).
-    if (detailNodeStats.statestats.nMisbehavior >= 0)
-        ui->peerBanScore->setText(QString("%1").arg(detailNodeStats.statestats.nMisbehavior));
-    else
-        ui->peerBanScore->setText(tr("Fetching..."));
+    ui->detailWidget->show();
 }
 
 void RPCConsole::resizeEvent(QResizeEvent *event)
 {
     QWidget::resizeEvent(event);
-    columnResizingFixer->stretchColumnWidth(PeerTableModel::Address);
 }
 
 void RPCConsole::showEvent(QShowEvent *event)
 {
     QWidget::showEvent(event);
 
-    // peerWidget needs a resize in case the dialog has non-default geometry
-    columnResizingFixer->stretchColumnWidth(PeerTableModel::Address);
+    if (!clientModel)
+        return;
 
-    // start the PeerTableModel refresh timer
-    clientModel->getPeerTableModel()->startAutoRefresh(1000);
+    // start PeerTableModel auto refresh
+    clientModel->getPeerTableModel()->startAutoRefresh();
 }
 
 void RPCConsole::hideEvent(QHideEvent *event)
 {
     QWidget::hideEvent(event);
+
+    if (!clientModel)
+        return;
 
     // stop PeerTableModel auto refresh
     clientModel->getPeerTableModel()->stopAutoRefresh();

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -6,24 +6,24 @@
 #define RPCCONSOLE_H
 
 #include "guiutil.h"
-#include "net.h"
-
 #include "peertablemodel.h"
 
+#include "net.h"
 
-#include <QWidget>
+#include <QDialog>
 
 class ClientModel;
 
+QT_BEGIN_NAMESPACE
 class QItemSelection;
-class CNodeCombinedStats;
+QT_END_NAMESPACE
 
 namespace Ui {
     class RPCConsole;
 }
 
 /** Local Bitcoin RPC console. */
-class RPCConsole: public QWidget
+class RPCConsole: public QDialog
 {
     Q_OBJECT
 
@@ -43,20 +43,6 @@ public:
 
 protected:
     virtual bool eventFilter(QObject* obj, QEvent *event);
-    void keyPressEvent(QKeyEvent *);
-
-private:
-    /** show detailed information on ui about selected node */
-    void updateNodeDetail(const CNodeCombinedStats *combinedStats);
-
-    enum ColumnWidths
-    {
-        ADDRESS_COLUMN_WIDTH = 250,
-        MINIMUM_COLUMN_WIDTH = 120
-    };
-
-    /** track the node that we are currently viewing detail on in the peers tab */
-    CNodeCombinedStats detailNodeStats;
 
 private Q_SLOTS:
     void on_lineEdit_returnPressed();
@@ -73,6 +59,7 @@ private Q_SLOTS:
 
 public Q_SLOTS:
     void clear();
+    void reject();
     void message(int category, const QString &message, bool html = false);
     /** Set number of connections shown in the UI */
     void setNumConnections(int count);
@@ -94,15 +81,23 @@ Q_SIGNALS:
 
 private:
     static QString FormatBytes(quint64 bytes);
+    void startExecutor();
     void setTrafficGraphRange(int mins);
+    /** show detailed information on ui about selected node */
+    void updateNodeDetail(const CNodeCombinedStats *stats);
+
+    enum ColumnWidths
+    {
+        ADDRESS_COLUMN_WIDTH = 200,
+        SUBVERSION_COLUMN_WIDTH = 100,
+        PING_COLUMN_WIDTH = 80
+    };
 
     Ui::RPCConsole *ui;
     ClientModel *clientModel;
     QStringList history;
-    GUIUtil::TableViewLastColumnResizingFixer *columnResizingFixer;
     int historyPtr;
-
-    void startExecutor();
+    NodeId cachedNodeid;
 };
 
 #endif // RPCCONSOLE_H


### PR DESCRIPTION
- add nodeID to peers table
- remove starting height as table header and replace with ping time
- remove columnResizingFixer
- rename Address to Address/Hostname
- rename secs to just s for ping time
- use MODEL_UPDATE_DELAY from guiconstants.h for the peer refresh time
- make PeerTableModel::columnCount() return no hard-coded value
- remove and cleanup dup private: section in RPCConsole header
- add new defaults for column sizes
- remove behaviour which keeps disconnected peers selected and also remove
  code which keeps track of last selected peer stats
- add sync height to detail view
- add some additional NULL pointer checks for clientModel in
  rpcconsole.cpp